### PR TITLE
CI: upgrade GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,9 +6,9 @@ jobs:
     strategy:
       matrix:
         go-version:
+          - 1.21.x
+          - 1.20.x
           - 1.19.x
-          # 'tip' doesn't exist on GitHub Actions :(
-          #- tip
           - 1.18.x
           - 1.17.x
           - 1.16.x

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,31 +37,14 @@ jobs:
         working-directory: ${{ env.GOPATH }}/src/github.com/${{ github.repository }}
     steps:
       # https://github.com/mvdan/github-actions-golang
-      - name: Install Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: ${{ matrix.go-version }}
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: ${{ env.GOPATH }}/src/github.com/${{ github.repository }}
-      - name: Go cache
-        # https://github.com/mvdan/github-actions-golang#how-do-i-set-up-caching-between-builds
-        uses: actions/cache@v2
+      - name: Install Go
+        uses: actions/setup-go@v4
         with:
-          # In order:
-          # * Module download cache
-          # * Build cache (Linux)
-          # * Build cache (Mac)
-          # * Build cache (Windows)
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-            ~/Library/Caches/go-build
-            %LocalAppData%\go-build
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          go-version: ${{ matrix.go-version }}
       - name: Check Import path
         run: GO111MODULE=off go list # Verify that go_import_path is ok for go < 1.11
       - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,14 @@ jobs:
         os:
           - ubuntu-latest
           - macos-latest
+        exclude:
+          # Old Go releases fail on recent MacOS.
+          - os: macos-latest
+            go-version: 1.10.x
+          - os: macos-latest
+            go-version: 1.9.x
+          - os: macos-latest
+            go-version: 1.8.x
         #arch:
         #  - amd64
         #  - ppc64le


### PR DESCRIPTION
* Upgrade actions
* Exclude old Go releases on MacOS because the just don't work
* Add recent Go versions